### PR TITLE
github workflows: add codeql permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,6 +14,14 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
 
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
These permissions are listed in the example CodeQL
file on the codeql-action repo, so we should add them
and ensure this works as often as possible.