### PR TITLE
github dependabot: add commit message prefixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,15 +10,21 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "go:"
 
   # Maintain dependencies for build tools
   - package-ecosystem: "gomod"
     directory: "/tools"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "go tools:"
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "github:"


### PR DESCRIPTION
These are going to be enforced by commitlint, so it
seems important that dependabot follows our requirements.