### PR TITLE
github workflows: simplify test matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: build
 
+env:
+  default_go_version: 1.18
+
 on:
   push: 
     branches: [ main ]
@@ -12,20 +15,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, macos-10.15, windows-2019 ]
+        os: [ ubuntu-20.04 ]
     runs-on: ${{ matrix.os }}
     defaults:
       run:
         shell: bash
     steps:
       - uses: actions/checkout@v3
-
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: ${{ env.default_go_version }}
 
-      - name: Build
+      - name: CI
         run: make ci
+
       - name: Upload coverage
         uses: actions/upload-artifact@v3
         with:
@@ -44,6 +47,24 @@ jobs:
           file: ./coverage.out
           flags: ${{ runner.os }}
 
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-20.04, macos-10.15, windows-2019 ]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.default_go_version }}
+
+      - name: Test
+        run: make test
+
   release-test:
     runs-on: ubuntu-20.04
     steps:
@@ -53,7 +74,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: ${{ env.default_go_version }}
 
       - name: Release test
         run: make build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   ci:
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os: [ ubuntu-20.04 ]
     runs-on: ${{ matrix.os }}
@@ -49,7 +49,7 @@ jobs:
 
   test:
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os: [ ubuntu-20.04, macos-10.15, windows-2019 ]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: release
 
+env:
+  default_go_version: 1.18
+
 on:
   push:
     tags:
@@ -15,7 +18,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: ${{ env.default_go_version }}
 
       - name: "Docker login"
         run: docker login docker.pkg.github.com -u docker -p ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This makes it so that instead of running the full CI build
on each possible OS, we only run our actual tests. The full
CI build is run on a different (usually subset) list of OS'.

The reason for this seperation is that we may want to add
many supported operating systems or many go versions
for which we should run tests. This should speed up builds
(and save money) without losing much information.

---

These tests are likely going to tell you the same information
in each matrix job. Given that, it is probably easier to read
and respond to a single failing job with some errors instead
of a dozen failing jobs with the same error.