### PR TITLE
github workflows: enable running tests on older go versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-20.04, macos-10.15, windows-2019 ]
+        go_version: [ 1.16, 1.17, 1.18 ]
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -60,7 +61,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.default_go_version }}
+          go-version: ${{ matrix.go_version }}
 
       - name: Test
         run: make test


### PR DESCRIPTION
For many libraries it is important to be compatible with a wide
array of go versions. That way different users in different
projects can all share this code. This adds the last two go
versions for a total of 3.