### PR TITLE
makefile: add build call to ci step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ dev: clean install generate vet fmt lint test mod-tidy
 
 .PHONY: ci
 ci: ## CI build
-ci: dev diff
+ci: dev build diff
 
 .PHONY: clean
 clean: ## remove files created during build pipeline


### PR DESCRIPTION
This is what should produce the dist folder output for
artifact generation. Since this is not happening we are
getting warnings during CI runs.