### PR TITLE
go *: change default version to 1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/zdylag/GoSeed
 
-go 1.18
+go 1.16


### PR DESCRIPTION
This is now three releases old, which seems like an alright
default to program into. The CI checks continue to verify
the repo is usable in 1.17 and 1.18, but since relying on
any 1.17+ features would mean the older versions would
not build anyways this seems safe to do.