### PR TITLE
devcontainer: add some helpful extensions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,11 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"golang.Go",
-		"ms-azuretools.vscode-docker"
+		"ms-azuretools.vscode-docker",
+		"eamodio.gitlens",
+		"mohsen1.prettify-json",
+		"ms-vscode.makefile-tools",
+		"DavidAnson.vscode-markdownlint"
 	],
 	
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.


### PR DESCRIPTION
These extensions are ones which will likely be useful when
developing in this repo in VSCode, regardless of the type of
library being built.